### PR TITLE
Add support for X509_CERT_DIR, fix host name printing, update to 2.8.19

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.34 		client: 2.8.18
-Date (yyyy/mm/dd):      servlet: 2014/10/29	client: 2016/02/16
+Product Version:        servlet: 3.34 		client: 2.8.19
+Date (yyyy/mm/dd):      servlet: 2014/10/29	client: 2016/04/12
 
 ------------------------------------------------------------------------
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -13,7 +13,7 @@
 #
 
 FN_VER_MAJOR	=	2
-FN_VER_MINOR	=	8.18
+FN_VER_MINOR	=	8.19
 COMPILER_TAG    =       $(CC)_$(shell $(CC) -dumpversion)
 PACKAGE_TAG     =       $(FN_VER_MAJOR).$(FN_VER_MINOR)__$(COMPILER_TAG)
 SRC_PACKAGE_TAG =       $(FN_VER_MAJOR).$(FN_VER_MINOR)__src

--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,3 +1,16 @@
+v2_8_19 - 12 Apr 2016 (dwd)
+  - Fix bug in the function that gets the name & IP address of servers
+    and proxies as a string.  This bug was introduced in v2_8_15.  The
+    function is supposed to return the host name followed by the IP
+    address in square brackets, however for proxies and for direct-
+    connect servers it was returning only the IP address in square
+    brackets.  This mostly affects warning & debug messages, but also
+    causes the digital signature checking option (security=sig) to
+    fail on direct-connect servers.
+  - Add support for $X509_CERT_DIR. If it is set and the capath option
+    is not set, it will be used as the directory containing CA certs
+    and CRLs instead of the default /etc/grid-security/certificates.
+
 v2_8_18 - 16 Feb 2016 (dwd)
   - Change the ordering of the linking options on the frontier client
     shared library, to get it to build properly on Ubuntu 12.04.

--- a/client/frontier_config.c
+++ b/client/frontier_config.c
@@ -38,7 +38,7 @@ static int default_write_timeout_secs=-1;
 static int default_max_age_secs=-1;
 static int default_prefer_ip_family=4;
 static int default_secured=0;
-static char *default_capath="/etc/grid-security/certificates";
+static char *default_capath=0;
 static char *default_force_reload=0;
 static char *default_freshkey=0;
 static int default_retrieve_zip_level=-1;
@@ -112,11 +112,19 @@ FrontierConfig *frontierConfig_get(const char *server_url,const char *proxy_url,
    }
   frontierConfig_setWriteTimeoutSecs(cfg,default_write_timeout_secs);
 
+  if(default_capath==0)
+   {
+    if((env=getenv("X509_CERT_DIR"))==0)
+      default_capath="/etc/grid-security/certificates";
+    else
+      default_capath=env;
+   }
+  frontierConfig_setCAPath(cfg,default_capath);
+
   // No env variable for these
   frontierConfig_setMaxAgeSecs(cfg,default_max_age_secs);
   frontierConfig_setPreferIpFamily(cfg,default_prefer_ip_family);
   frontierConfig_setSecured(cfg,default_secured);
-  frontierConfig_setCAPath(cfg,default_capath);
 
   if(default_force_reload==0)
    {

--- a/client/http/fn-htclient.c
+++ b/client/http/fn-htclient.c
@@ -1030,7 +1030,7 @@ static char *curhostname(FrontierHostsInfo *fhi)
     buf[len-1]='\0';
    }
 
-   return buf;
+   return fhi->debugbuf;
  }
 
 char *frontierHttpClnt_curproxyname(FrontierHttpClnt *c)

--- a/docs/FrontierClientUsage.html
+++ b/docs/FrontierClientUsage.html
@@ -179,6 +179,7 @@ signatures on every response.  Requires access to a directory of
 Certifying Authority certificates and CRLs.
 <li>
 capath - Directory containing Certifying Authority certificates and CRLs.
+If not present, may come from environment variable X509_CERT_DIR.
 Default is /etc/grid-security/certificates.
 </ul>
 


### PR DESCRIPTION
See [FTAPPDEVEL-96](https://its.cern.ch/jira/browse/FTAPPDEVEL-96)
