### PR TITLE
When overriding Last-Modified, use oldest datestamp instead of blank

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.38 		client: 2.8.20
-Date (yyyy/mm/dd):      servlet: 2017/05/24	client: 2016/11/03
+Product Version:        servlet: 3.39 		client: 2.8.20
+Date (yyyy/mm/dd):      servlet: 2018/01/23	client: 2016/11/03
 
 ------------------------------------------------------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,14 @@
 $Id$
 
+3.39 2018/01/23 (dwd)
+    - When responding with an error condition before headers are sent,
+      instead of setting a Last-Modified header to be blank, set it
+      to the oldest possible time of midnight on January 1, 1970. 
+      With the old behavior, Squid-3 does not clear the cache even
+      though Squid-2 does.  With the new behavior, squid-3 always
+      clears the cache even with another error sends the same
+      Last-Modified time.
+
 3.38 2017/05/24 (dwd)
     - Add log message after DB data transferred including the msecs
       it took to transfer the data.

--- a/src/gov/fnal/frontier/FrontierServlet.java
+++ b/src/gov/fnal/frontier/FrontierServlet.java
@@ -21,7 +21,7 @@ import com.jcraft.jzlib.*;
 
 public final class FrontierServlet extends HttpServlet 
  {
-  private static final String frontierVersion="3.38";
+  private static final String frontierVersion="3.39";
   private static final String xmlVersion="1.0";
   private static int count_total=0;
   private static int count_current=0;

--- a/src/gov/fnal/frontier/FrontierServlet.java
+++ b/src/gov/fnal/frontier/FrontierServlet.java
@@ -122,9 +122,13 @@ public final class FrontierServlet extends HttpServlet
      {
       // tell proxies to cache the error for a short time
       setAgeExpires(request,response,error_max_age);
-      // this leaves an empty header but it doesn't hurt and
-      //  there doesn't appear to be any way to delete a header
-      response.setHeader("Last-Modified","");
+      // There doesn't appear to be any way to delete a header, so set
+      //  the Last-Modified time to the oldest possible time, so any
+      //  newer response will override it. Both squid and this servlet
+      //  treat a zero datestamp as if Last-Modified never matches, so
+      //  even if an error condition persists but the message changes,
+      //  the message will get updated.
+      response.setHeader("Last-Modified",dateHeader(0));
      }
     ResponseFormat.payload_end(out,1,descript,max_age,check,-1,0);
     return msg;


### PR DESCRIPTION
See [FTAPPDEVEL-132](https://its.cern.ch/jira/browse/FTAPPDEVEL-132)