### PR TITLE
Ignore text before the "BEGIN" line in the private key, update to 3.40

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.39 		client: 2.8.20
-Date (yyyy/mm/dd):      servlet: 2018/01/23	client: 2016/11/03
+Product Version:        servlet: 3.40 		client: 2.8.20
+Date (yyyy/mm/dd):      servlet: 2018/08/20	client: 2016/11/03
 
 ------------------------------------------------------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,9 @@
 $Id$
 
+3.40 2018/08/20 (dwd)
+    - Ignore any text before the BEGIN line in the private key file.
+      This appears to have been done in 3.33 but lost in 3.34.
+
 3.39 2018/01/23 (dwd)
     - When responding with an error condition before headers are sent,
       instead of setting a Last-Modified header to be blank, set it

--- a/src/gov/fnal/frontier/FrontierServlet.java
+++ b/src/gov/fnal/frontier/FrontierServlet.java
@@ -21,7 +21,7 @@ import com.jcraft.jzlib.*;
 
 public final class FrontierServlet extends HttpServlet 
  {
-  private static final String frontierVersion="3.39";
+  private static final String frontierVersion="3.40";
   private static final String xmlVersion="1.0";
   private static int count_total=0;
   private static int count_current=0;


### PR DESCRIPTION
The private key parser was not ignoring text before the BEGIN line like it should have been.