### PR TITLE
Fix compiling issue appearing on centos8

### DIFF
--- a/client/frontier.c
+++ b/client/frontier.c
@@ -523,8 +523,14 @@ static char *vcb_curservername;
 static int cert_verify_callback(int ok,X509_STORE_CTX *ctx)
  {
   if (!ok)
-    frontier_setErrorMsg(__FILE__,__LINE__, "error verifying server %s cert: %s",vcb_curservername,X509_verify_cert_error_string(ctx->error));
-  return ok;
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+    frontier_setErrorMsg(__FILE__,__LINE__, "error verifying server %s cert: %s",vcb_curservername,
+			                    X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
+#else
+    frontier_setErrorMsg(__FILE__,__LINE__, "error verifying server %s cert: %s",vcb_curservername,
+			                    X509_verify_cert_error_string(ctx->error));
+#endif
+    return ok;
  }
  
 static int get_cert(Channel *chn,const char *uri,int curserver)


### PR DESCRIPTION
Add support for OpenSSL 1.1.1 .
Compiling on CentOS8 fails because of a change in which X509_STORE_CTX related errors are accessed. The patch fixes this failure.