### PR TITLE
Remove extra slash at beginning of http queries

### DIFF
--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,3 +1,6 @@
+  - Remove extra slash at the beginning of all http queries, introduced
+    in 2.8.21 (with the ipv6 square brackets feature).
+
 v2_9_0 - 22 Jan 2020 (dwd)
   - Add the frontier_statistics C API.  Collects the number of queries,
     the number of errors in fetches, and the min, max, and average of

--- a/client/http/fn-urlparse.c
+++ b/client/http/fn-urlparse.c
@@ -110,7 +110,7 @@ FrontierUrlInfo *frontier_CreateUrlInfo(const char *url,int *ec)
       *ec=FRONTIER_ECFG;
       goto err;
      }
-    fui->path=frontier_str_copy(p);
+    fui->path=frontier_str_copy(p+1);
    }
 
   *ec=FRONTIER_OK;


### PR DESCRIPTION
[FTAPPDEVEL-164](https://its.cern.ch/jira/browse/FTAPPDEVEL-164)