### PR TITLE
Make DNS errors for proxyconfigurl into debug messages instead of warning

### DIFF
--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,5 +1,8 @@
   - Remove extra slash at the beginning of all http queries, introduced
     in 2.8.21 (with the ipv6 square brackets feature).
+  - Make "Name or service not known" warning messages for proxyconfigurls
+    into debug messages, since it is recommended to try grid-wpad and wpad
+    even though in most cases the names do not exist.
 
 v2_9_0 - 22 Jan 2020 (dwd)
   - Add the frontier_statistics C API.  Collects the number of queries,

--- a/client/frontier_config.c
+++ b/client/frontier_config.c
@@ -821,6 +821,7 @@ int frontierConfig_doProxyConfig(FrontierConfig *cfg)
   char *ipaddr,*proxylist;
   char *p,*endp,endc;
   int gotdirect=0;
+  int trynextloglevel;
 
   if(cfg->proxyconfig_num<=0)
     return FRONTIER_OK;
@@ -938,11 +939,14 @@ int frontierConfig_doProxyConfig(FrontierConfig *cfg)
      }
 
     frontier_turnErrorsIntoDebugs(1);
+    trynextloglevel=FRONTIER_LOGLEVEL_WARNING;
 
     ret=frontierHttpClnt_open(clnt);
     if(ret!=FRONTIER_OK)
      {
-      frontier_log(FRONTIER_LOGLEVEL_WARNING,__FILE__,__LINE__,
+      if (strstr(frontier_getErrorMsg(),"Name or service not known")!=0)
+        trynextloglevel=FRONTIER_LOGLEVEL_DEBUG;
+      frontier_log(trynextloglevel,__FILE__,__LINE__,
 	 "unable to connect to proxyconfig server %s: %s",
 		frontierHttpClnt_curservername(clnt), frontier_getErrorMsg());
       goto trynext;
@@ -1002,7 +1006,7 @@ trynext:
 	    (strncmp(cfg->proxyconfig[curproxyconfig],"file://",7)==0))
        {
         // there is a file:// URL still to try
-        frontier_log(FRONTIER_LOGLEVEL_WARNING,__FILE__,__LINE__,
+        frontier_log(trynextloglevel,__FILE__,__LINE__,
           "Trying next proxyconfig url %s", cfg->proxyconfig[curproxyconfig]);
        }
       else
@@ -1016,7 +1020,7 @@ trynext:
     else
      {
       curproxyconfig=nextproxyconfig;
-      frontier_log(FRONTIER_LOGLEVEL_WARNING,__FILE__,__LINE__,
+      frontier_log(trynextloglevel,__FILE__,__LINE__,
         "Trying next proxyconfig server %s",
 	 	frontierHttpClnt_curservername(clnt));
      }


### PR DESCRIPTION
[FTAPPDEVEL-107](https://its.cern.ch/jira/browse/FTAPPDEVEL-107)