### PR TITLE
Fix for gcc 10.1's default -fno-common

### DIFF
--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,3 +1,5 @@
+  - Fix to compile with gcc 10.1's new default -f-no-common option
+
 v2_9_1 - 19 Mar 2020 (dwd)
   - Remove extra slash at the beginning of all http queries, introduced
     in 2.8.21 (with the ipv6 square brackets feature).

--- a/client/frontier_config.c
+++ b/client/frontier_config.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include "pacparser.h"
+#include "fn-internal.h"
 #include <http/fn-htclient.h>
 #include "frontier_client/frontier_config.h"
 #include "frontier_client/frontier_log.h"
@@ -46,9 +47,6 @@ static char *default_logical_server=0;
 static char *default_physical_servers=0;
 
 #define ENV_BUF_SIZE	1024
-
-void *(*frontier_mem_alloc)(size_t size);
-void (*frontier_mem_free)(void *ptr);
 
 int frontier_pacparser_init(void);
 


### PR DESCRIPTION
Fix for issue #34 