### PR TITLE
Update frontier-client to support pacparser v1.4.2

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.41 		client: 2.10.1
-Date (yyyy/mm/dd):      servlet: 2019/12/31	client: 2023/4/7
+Product Version:        servlet: 3.41 		client: 2.10.2
+Date (yyyy/mm/dd):      servlet: 2019/12/31	client: 2023/6/13
 
 ------------------------------------------------------------------------
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -13,7 +13,7 @@
 #
 
 FN_VER_MAJOR	=	2
-FN_VER_MINOR	=	10.1
+FN_VER_MINOR	=	10.2
 COMPILER_TAG    =       $(CC)_$(shell $(CC) -dumpversion)
 PACKAGE_TAG     =       $(FN_VER_MAJOR).$(FN_VER_MINOR)__$(COMPILER_TAG)
 SRC_PACKAGE_TAG =       $(FN_VER_MAJOR).$(FN_VER_MINOR)__src

--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,3 +1,10 @@
+v2_10_2 - 13 Jun 2023 (cvuosalo)
+  - Update to be compatible with pacparser v1.4.2, which has a security
+    fix that prevents injection of arbirtray code for execution. With some
+    versions of some compilers, such as gcc 4.8.5, the following line must
+    be added to the pacparser v1.4.2 Makefile:
+    CFLAGS = -std=gnu99
+
 v2_10_1 - 7 Apr 2023 (cvuosalo)
   - Add Python bindings and related patch that CMS has been using.
   - Fix to compile with gcc 10.1's new default -f-no-common option.

--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,6 +1,6 @@
 v2_10_2 - 13 Jun 2023 (cvuosalo)
   - Update to be compatible with pacparser v1.4.2, which has a security
-    fix that prevents injection of arbirtray code for execution. With some
+    fix that prevents injection of arbitrary code for execution. With some
     versions of some compilers, such as gcc 4.8.5, the following line must
     be added to the pacparser v1.4.2 Makefile:
     CFLAGS = -std=gnu99

--- a/client/pacparser-dlopen.c
+++ b/client/pacparser-dlopen.c
@@ -20,7 +20,7 @@
 static void *pp_dlhandle;
 static int (*pp_init)(void);
 static void (*pp_set_error_printer)(pacparser_error_printer);
-static void (*pp_setmyip)(const char *);
+static int (*pp_setmyip)(const char *);
 static int (*pp_parse_pac_string)(const char *);
 static char *(*pp_find_proxy)(const char *,const char *);
 static void (*pp_cleanup)(void);
@@ -91,11 +91,11 @@ void pacparser_set_error_printer(pacparser_error_printer func)
   return;
  }
 
-void pacparser_setmyip(const char *ip)
+int pacparser_setmyip(const char *ip)
  {
   if(!pp_dlhandle)
-    return;
-  (*pp_setmyip)(ip);
+    return 0;
+  return (*pp_setmyip)(ip);
  }
 
 int pacparser_parse_pac_string(const char *string)


### PR DESCRIPTION
Update to be compatible with pacparser v1.4.2, which has a security fix that prevents injection of arbitrary code for execution. With some versions of some compilers, such as gcc 4.8.5, the following line must be added to the pacparser v1.4.2 Makefile: 

`CFLAGS = -std=gnu99`

The pacparser v1.4.2 `pacparser.h` changes the declaration of `pacparser_setmyip()`, requiring a corresponding change in the client's `pacparser-dlopen.c`. Even with this change, testing indicates that the new version of the frontier-client will still work with the old 1.3.7 version of pacparser.

The following testing procedure exercised pacparser and showed correct operation:
```
setenv FRONTIER_SERVER1 http://cmsfrontier.cern.ch:8000/FrontierProd
setenv FRONTIER_PROXY1 http://cmsmeyproxy.cern.ch
setenv LD_LIBRARY_PATH .
setenv FRONTIER_PROXYCONFIGS http://wlcg-wpad.fnal.gov/wpad.dat
setenv FRONTIER_LOG_LEVEL debug
. ./fn-req -f test.sql
where test.sql is "select 1 from dual"
```
Tests were also done on `cmsfrontier7.cern.ch` with a different proxy config:
```
setenv FRONTIER_PROXYCONFIGS http://wlcg-wpad.cern.ch/wpad.dat
```
