### PR TITLE
makefile: allow overriding c++ compiler executable via env variable CXX

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -58,12 +58,12 @@ CFLAGS		=	$(DEBUG_OPTIM)
 CXXFLAGS	=	$(DEBUG_OPTIM)
 FNAPI_VERSION	=	$(FN_VER_MAJOR).$(FN_VER_MINOR)
 CC		=	gcc
-CXX		=	c++
+CXX		?=	c++
 CXXOPT_LIB	=	-Wall $(CXXFLAGS) -DFRONTIER_DEBUG -DFNTR_USE_NAMESPACE -DFNTR_USE_EXCEPTIONS -fPIC -DPIC
 CXXOPT_APP	=	-Wall $(CXXFLAGS) -DFRONTIER_DEBUG -DFNTR_USE_NAMESPACE -DFNTR_USE_EXCEPTIONS -fPIC -DPIC
 COPT		=	-Wall $(CFLAGS) -DFRONTIER_DEBUG -fPIC -DPIC
-LINK_SO         =       c++ $(CXXFLAGS) -shared -o libfrontier_client.so.$(FN_VER_MAJOR).$(FN_VER_MINOR) -Wl,-soname,libfrontier_client.so.$(FN_VER_MAJOR)
-LINK_DYLIB	=	c++ $(CXXFLAGS) -dynamiclib -undefined dynamic_lookup  -compatibility_version $(FN_VER_MAJOR) -current_version $(FN_VER_MAJOR).$(FN_VER_MINOR) -o libfrontier_client.$(FN_VER_MAJOR).$(FN_VER_MINOR).dylib -single_module $(LIBS)
+LINK_SO	=	$(CXX) $(CXXFLAGS) -shared -o libfrontier_client.so.$(FN_VER_MAJOR).$(FN_VER_MINOR) -Wl,-soname,libfrontier_client.so.$(FN_VER_MAJOR)
+LINK_DYLIB	=	$(CXX) $(CXXFLAGS) -dynamiclib -undefined dynamic_lookup  -compatibility_version $(FN_VER_MAJOR) -current_version $(FN_VER_MAJOR).$(FN_VER_MINOR) -o libfrontier_client.$(FN_VER_MAJOR).$(FN_VER_MINOR).dylib -single_module $(LIBS)
 LINK		=	ar cr libfrontier_client.a
 
 COMMON_INC	=	${EXPAT_INC} ${OPENSSL_INC} ${PACPARSER_INC} ${ZLIB_INC}

--- a/client/RELEASE_NOTES
+++ b/client/RELEASE_NOTES
@@ -1,3 +1,6 @@
+  - Allow the c++ compiler to be overridden in the Makefile by setting
+    the CXX variable.  This was needed to compile for Ubuntu24 for LCG.
+
 v2_10_2 - 13 Jun 2023 (cvuosalo)
   - Update to be compatible with pacparser v1.4.2, which has a security
     fix that prevents injection of arbitrary code for execution. With some


### PR DESCRIPTION
This change allows us to build the frontier client on ubuntu24 for the LCG stacks where the c++ executable / alias is not defined, but we can just set it via the CXX variable.
