### PR TITLE
Convert servlet to Jakarta EE for frontier-tomcat-10.1.54

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.42 		client: 2.10.2
-Date (yyyy/mm/dd):      servlet: 2024/06/04	client: 2023/6/13
+Product Version:        servlet: 3.43 		client: 2.10.2
+Date (yyyy/mm/dd):      servlet: 2026/05/21	client: 2023/6/13
 
 ------------------------------------------------------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,8 +1,12 @@
 $Id$
 
+3.43 2026/05/21 (cvuosalo)
+    - Migrate Frontier.war to Jakarta-EE to support
+      frontier-tomcat-10.1.54.
+
 3.42 2024/06/04 (cvuosalo)
     - Add support for https in URLs specified by the FileBaseDirectory
-    configuration variable.
+      configuration variable.
 
 3.41 2019/12/31 (dwd)
     - When a "X-Frontier-Opts: DontCacheErrors" request header is set, 


### PR DESCRIPTION
frontier-tomcat-10.1.54 requires the servlet to support Jakarta EE. A conversion step has been added to the process of building the servlet. This new version of the servlet has a new version number, but its source code is otherwise unchanged.

This change goes along with the frontier-tomcat update to 10.1.54:

https://gitlab.cern.ch/frontier/rpms/frontier-tomcat/-/merge_requests/11