### PR TITLE
Update Frontier servlet version number to 3.43

### DIFF
--- a/src/gov/fnal/frontier/FrontierServlet.java
+++ b/src/gov/fnal/frontier/FrontierServlet.java
@@ -21,7 +21,7 @@ import com.jcraft.jzlib.*;
 
 public final class FrontierServlet extends HttpServlet 
  {
-  private static final String frontierVersion="3.42";
+  private static final String frontierVersion="3.43";
   private static final String xmlVersion="1.0";
   private static int count_total=0;
   private static int count_current=0;


### PR DESCRIPTION
In PR #52 I forgot to also update the version number in the Frontier servlet Java code. This PR fixes that oversight.
The only change in PR #52 is that the `war` file gets migrated to Jakarta EE. The code itself doesn't change.

I tested that the Jakarta EE migration is required. Without migration, frontier-tomcat responds to requests with a 404 error.