### PR TITLE
Update Frontier Project Notes for Jakarta EE migration

### DIFF
--- a/docs/FrontierProjectNotes.html
+++ b/docs/FrontierProjectNotes.html
@@ -133,6 +133,9 @@ Prepare and release the sources:
 <br>
 <tt>scp Frontier_servlet__`echo $SERVLETVERSION|tr _ .`__src.tar.gz dbfrontier@frontier.cern.ch:dist</tt>
 <li>
+Download the Jakarta EE migration tool: https://tomcat.apache.org/download-migration.cgi
+<br>
+<li>
 Prepare and release the binaries:
 <br>
 <tt>cd Frontier_$SERVLETVERSION</tt>
@@ -143,10 +146,6 @@ Prepare and release the binaries:
 <br>
 (where CATALINA_HOME is set to the top level directory of a tomcat
 installation)
-<br>
-<tt># Migrate to Jakarta EE
-<br>
-<tt>Download Jakarta EE migration tool: https://tomcat.apache.org/download-migration.cgi
 <br>
 <tt>java -jar jakartaee-migration-1.0.10/lib/jakartaee-migration-1.0.10.jar dist/Frontier.war dist/FrontierJEE.war
 <br>

--- a/docs/FrontierProjectNotes.html
+++ b/docs/FrontierProjectNotes.html
@@ -144,6 +144,14 @@ Prepare and release the binaries:
 (where CATALINA_HOME is set to the top level directory of a tomcat
 installation)
 <br>
+<tt># Migrate to Jakarta EE
+<br>
+<tt>Download Jakarta EE migration tool: https://tomcat.apache.org/download-migration.cgi
+<br>
+<tt>java -jar jakartaee-migration-1.0.10/lib/jakartaee-migration-1.0.10.jar dist/Frontier.war dist/FrontierJEE.war
+<br>
+<tt>mv dist/FrontierJEE.war dist/Frontier.war
+<br>
 <tt>scp dist/Frontier.war dbfrontier@frontier.cern.ch:dist/Frontier_`echo $SERVLETVERSION|tr _ .`.war</tt>
 <br>
 <tt>scp RELEASE_NOTES dbfrontier@frontier.cern.ch:dist/servletreleasenotes.txt</tt>


### PR DESCRIPTION
The Frontier Project Notes web page needed updating for instructions about migrating the servlet to Jakarta EE. The revised page is already in place and can be viewed [here](https://frontier.cern.ch/dist/FrontierProjectNotes.html).