### PR TITLE
Fix output length of Base64 decoded keys

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           Frontier
-Product Version:        servlet: 3.43 		client: 2.10.2
-Date (yyyy/mm/dd):      servlet: 2026/05/21	client: 2023/6/13
+Product Version:        servlet: 3.44 		client: 2.10.2
+Date (yyyy/mm/dd):      servlet: 2026/06/16	client: 2023/6/13
 
 ------------------------------------------------------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,8 @@
 $Id$
 
+3.44 2026/06/16 (cvuosalo)
+    - Fix Base64 decoding of keys so the output size is correct.
+
 3.43 2026/05/21 (cvuosalo)
     - Migrate Frontier.war to Jakarta-EE to support
       frontier-tomcat-10.1.54.

--- a/src/gov/fnal/frontier/FrontierServlet.java
+++ b/src/gov/fnal/frontier/FrontierServlet.java
@@ -21,7 +21,7 @@ import com.jcraft.jzlib.*;
 
 public final class FrontierServlet extends HttpServlet 
  {
-  private static final String frontierVersion="3.43";
+  private static final String frontierVersion="3.44";
   private static final String xmlVersion="1.0";
   private static int count_total=0;
   private static int count_current=0;

--- a/src/gov/fnal/frontier/codec/Base64Coder.java
+++ b/src/gov/fnal/frontier/codec/Base64Coder.java
@@ -127,17 +127,17 @@ public static int encode (byte[] in, int ip, int iLen, byte[] out, int op) {
 */
 public static byte[] decode (byte[] in) {
    int iLen = in.length;
-   int padLen = 0;
-   while (iLen > 0 && in[iLen-1] == '=') {
-      iLen--;
-      padLen++;
-   }
+   while (iLen > 0 && in[iLen-1] == '=') iLen--;
+
    // Decoding converts every 4 encoded bytes into 3 bytes. The encoded value was padded
-   // to make its length a multiple of 4.
-   // For some integer n, original iLen must be 4n. After padding stripped, if padLen==1,
-   // then with m=n-1, iLen==(4m+3) bytes. Decoded length is 3m+2.
-   // If padLen==2, then iLen=(4m+2) bytes. Decoded length is 3m+1.
-   int oLen = ((iLen * 3) - padLen) / 4;
+   // to make its length a multiple of 4. Each encoded byte is decoded into a 6-bit word.
+   // For some integer n, original iLen must be 4n.  After any padding is stripped
+   // off, decoding will transform input length to output length as follows, with m=n-1:
+   // 4n -> 3n
+   // 4m+2 -> 3m+1 (in the formula below, 3m+int(6/4) = 3m+1) (4 bits dropped at end)
+   // 4m+3 -> 3m+2 (in the formula below, 3m+int(9/4) = 3m+2) (2 bits dropped at end)
+
+   int oLen = (iLen * 3) / 4;
 
    byte[] out = new byte[oLen];
    int ip = 0;

--- a/src/gov/fnal/frontier/codec/Base64Coder.java
+++ b/src/gov/fnal/frontier/codec/Base64Coder.java
@@ -127,8 +127,18 @@ public static int encode (byte[] in, int ip, int iLen, byte[] out, int op) {
 */
 public static byte[] decode (byte[] in) {
    int iLen = in.length;
-   while (iLen > 0 && in[iLen-1] == '=') iLen--;
-   int oLen = ((iLen*3)+2) / 4;
+   int padLen = 0;
+   while (iLen > 0 && in[iLen-1] == '=') {
+      iLen--;
+      padLen++;
+   }
+   // Decoding converts every 4 encoded bytes into 3 bytes. The encoded value was padded
+   // to make its length a multiple of 4.
+   // For some integer n, original iLen must be 4n. After padding stripped, if padLen==1,
+   // then with m=n-1, iLen==(4m+3) bytes. Decoded length is 3m+2.
+   // If padLen==2, then iLen=(4m+2) bytes. Decoded length is 3m+1.
+   int oLen = ((iLen * 3) - padLen) / 4;
+
    byte[] out = new byte[oLen];
    int ip = 0;
    int op = 0;


### PR DESCRIPTION
The Base64Coder was added to frontier-tomcat in 2007. It was modified shortly thereafter, and a small bug was introduced. This bug added a byte to the output of the decoder when the encoded key had two padding characters. This bug had no effect until now, when more modern libraries rejected decoded keys with a trailing random byte for the case of encoded keys had two padding characters. The bug was only noticed on machines that happened to have host keys with two padding characters.

To prevent any future confusion about this code, not only has the bug been fixed, but a comment has been added to the code to help explain how the fix is correct.

This fix was tested on cmsfrontier7 with two different sized keys. During testing, `println` statements were added to show the input and output lengths to confirm that the calculation was correct.